### PR TITLE
connect update a user information with firebase auth and firestore issue #25

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,9 +6,15 @@ import Login from './container/Login/Login';
 
 import Build from './container/Build/Build';
 
-import Settings from './component/Settings/Settings.js'
+import Settings from './component/Settings/Settings.js';
+import Reauthenticate from './container/Settings/UserSettings/Reauthenticate';
 import BuildSettings from './container/Settings/BuildSettings/BuildSettings';
 import UserSettings from './container/Settings/UserSettings/UserSettings';
+
+import UserSettingsUpdateEmail from './container/Settings/UserSettings/UserSettingsForms/UpdateUserEmail';
+import UserSettingsUpdatePassword from './container/Settings/UserSettings/UserSettingsForms/UpdateUserPassword';
+import UserSettingsUpdateUsername from './container/Settings/UserSettings/UserSettingsForms/UpdateUserUsername';
+
 
 import DisplayBuild from './container/DisplayBuild/DisplayBuild';
 import Home from './container/Home/Home';
@@ -24,8 +30,14 @@ function App() {
       <Route path='/build/:id' exact component={DisplayBuild} />
       <Route path='/build' exact component={Build} />
       <Route path='/editbuild' exact component={BuildSettings} />
-      <Route path='/usersettings' exact component={UserSettings} />
       <Route path='/settings' exact component={Settings} />
+      <Route path='/reauthenticate' exact component={Reauthenticate} />
+
+
+      <Route path='/usersettings' exact component={UserSettings} />
+      <Route path='/updateemail' exact component={UserSettingsUpdateEmail} />
+      <Route path='/updatepassword' exact component={UserSettingsUpdatePassword} />
+      <Route path='/updateusername' exact component={UserSettingsUpdateUsername} />
     </BrowserRouter>
   );
 }

--- a/src/component/NavBar/NavBar.js
+++ b/src/component/NavBar/NavBar.js
@@ -9,7 +9,7 @@ const NavBar = (props) => {
 
   // when a user signs in with firebase auth it provides a property 'uid'
   // if the user is signed in show them build and logout links
-  // if they are not logged in showthe register and login links
+  // if they are not logged in show the register and login links
   const links = auth.uid ? (
     <React.Fragment>
       <Link to='/build'>Build</Link>

--- a/src/container/Login/Login.js
+++ b/src/container/Login/Login.js
@@ -26,8 +26,9 @@ class Login extends Component {
   render () {
     const  { authError, auth } = this.props;
 
-    if (auth.uid) return <Redirect to='/' />
-
+    if (auth.uid) {
+      return <Redirect to='/' />
+    }
     return (
       <form onSubmit={this.handleSubmit}>
         <div>
@@ -61,7 +62,6 @@ class Login extends Component {
 }
 
 const mapStateToProps = (state) => {
-  console.log(state)
   return {
     authError: state.auth.authError,
     auth: state.firebase.auth

--- a/src/container/Settings/UserSettings/Reauthenticate.js
+++ b/src/container/Settings/UserSettings/Reauthenticate.js
@@ -1,0 +1,96 @@
+/**
+ * this was made for when a user tries to change there email or password
+ * have to reauthenticate for it to work
+ * https://firebase.google.com/docs/auth/web/manage-users#re-authenticate_a_user
+ */
+
+ import React, { Component } from 'react';
+
+import {reauthenticateUser} from '../../../store/actions/authActions';
+import { connect } from 'react-redux';
+
+
+ class Reauthenticate extends Component {
+   state = {
+     email: '',
+     password: ''
+   }
+
+   handleChange = (ev) => {
+     this.setState({
+       [ev.target.id]: ev.target.value
+     });
+
+   }
+
+   handleSubmit = (ev) => {
+     ev.preventDefault();
+     //reauthenticate user with the info
+     this.props.reauthenticate(this.state);
+   }
+
+   render () {
+    //  need to return some sort of jsx before pushing 
+    // to a new url
+     if (this.props.reauthenticateSuccess) {
+       this.props.history.goBack();
+       return ( <p> redirecting...</p> )
+     }
+
+     return (
+       <React.Fragment>
+         <div>
+           <h2>
+             ReAuthentication is required
+           </h2>
+           <p>because you tried to change your email or password</p>
+         </div>
+
+         <form onSubmit={this.handleSubmit}>
+           <div>
+             <label htmlFor="email">
+               Email:
+             </label>
+             <input 
+              type="email" 
+              id="email" 
+              onChange={this.handleChange} />
+           </div>
+           <div>
+             <label htmlFor="password">
+               Password:
+             </label>
+             <input
+               type="password"
+               id="password"
+               onChange={this.handleChange} />
+           </div>
+
+           <button>
+             reauthenticate
+           </button>
+
+           { this.props.authError ? <p>{ this.props.authError }</p> : null }
+         </form>
+       </React.Fragment>
+     )
+   }
+ }
+
+ const mapStateToProps = (state) => {
+   return {
+     ...state,
+     authError: state.auth.authError,
+     reauthenticateSuccess: state.auth.reauthenticateSuccess
+   }
+ }
+
+ const mapDispatchToProps = (dispatch) => {
+   return {
+     reauthenticate: (credentials) => {
+       dispatch(reauthenticateUser(credentials));
+     }
+   }
+ }
+
+ export default connect(mapStateToProps, mapDispatchToProps)(Reauthenticate);

--- a/src/container/Settings/UserSettings/UserSettings.js
+++ b/src/container/Settings/UserSettings/UserSettings.js
@@ -1,56 +1,47 @@
 import React, { Component } from 'react';
 
+import { connect } from 'react-redux';
+import { Redirect, Link } from 'react-router-dom';
+
+import { resetStateForUpdateUserAction } from '../../../store/actions/authActions';
+
+
 class UserSettings extends Component {
-  state = {
-    username: '',
-    email: '',
-    password: ''
-  }
 
-  onChange = (ev) => {
-    this.setState({
-      [ev.target.id]: ev.target.value
-    })
-  }
-
-  onSubmit = (ev) => {
-    ev.preventDefault();
-
-    console.log(this.state);
+  componentWillMount() {
+    // reset the state of weather the user is updated
+    // when it reaches this page so the user can update their
+    // information again
+    this.props.resetStateForUpdateUser();
   }
 
   render () {
+    if (!this.props.auth.uid) {
+      return <Redirect to='/login' />
+    }
     return (
-      <form onSubmit={this.onSubmit}>
-        <div>
-          <label htmlFor="email">Email: </label>
-          <input type="email" 
-            id="email" 
-            onChange={this.onChange} 
-            value={this.state.email} />
-        </div>
-        <div>
-          <label htmlFor="username">Username: </label>
-          <input type="text"
-            id="username"
-            onChange={this.onChange}
-            value={this.state.username} />
-        </div>
-        <div>
-          <label htmlFor="password">Password: </label>
-          <input type="password"
-            id="password"
-            onChange={this.onChange}
-            value={this.state.password} />
-        </div>
-        <div>
-          <button>
-            update
-          </button>
-        </div>
-      </form>
+      <div>
+        <Link to='/updateemail'>update email</Link>
+        <Link to='/updatepassword'>update password</Link>
+        <Link to='/updateusername'>update username</Link>
+      </div>
     )
   }
 }
 
-export default UserSettings;
+const mapStateToProps = (state) => {
+  return {
+    ...state,
+    auth: state.firebase.auth
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    resetStateForUpdateUser: () => {
+      dispatch(resetStateForUpdateUserAction());
+    }
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(UserSettings);

--- a/src/container/Settings/UserSettings/UserSettingsForms/UpdateUserEmail.js
+++ b/src/container/Settings/UserSettings/UserSettingsForms/UpdateUserEmail.js
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+import { updateUserEmailAction } from '../../../../store/actions/authActions';
+
+
+
+class UpdateUserEmail extends Component {
+  state = {
+    email: ''
+  }
+
+  componentDidMount() {
+    if (!this.props.reauthenticateSuccess) {
+      this.props.history.push('/reauthenticate');
+    }
+  }
+
+  handleChange = (ev) => {
+    this.setState({
+      [ev.target.id]: ev.target.value
+    })
+  }
+
+  handleSubmit = (ev) => {
+    ev.preventDefault();
+ 
+    this.props.updateUserEmail(this.state);
+  }
+
+  render () {
+
+    console.log(this.props)
+    if (this.props.userUpdated) {
+      this.props.history.goBack();
+      return (<p> redirecting.. </p>);
+
+    }
+  
+    if (!this.props.auth.uid) {
+      return <Redirect to='/login' />
+    }
+    return (
+      <div>
+        <h2>
+          update email
+        </h2>
+        <form onSubmit={this.handleSubmit}>
+          <div>
+            <label htmlFor="email">Email: </label>
+            <input type="email"
+              id="email"
+              onChange={this.handleChange}
+              value={this.state.email} />
+          </div>
+          <button>
+            update
+        </button>
+          {this.props.authError ? <p>{this.props.authError}</p> : null}
+
+          {this.props.userUpdated ? <p> updated email successfully </p> : null}
+        </form>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state) => {
+  console.log(state)
+  return {
+    auth: state.firebase.auth,
+    authError: state.auth.authError,
+    reauthenticateSuccess: state.auth.reauthenticateSuccess,
+    userUpdated: state.auth.userUpdated
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    updateUserEmail: (updateUser) => {
+      dispatch(updateUserEmailAction(updateUser));
+    }
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(UpdateUserEmail)

--- a/src/container/Settings/UserSettings/UserSettingsForms/UpdateUserPassword.js
+++ b/src/container/Settings/UserSettings/UserSettingsForms/UpdateUserPassword.js
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+import { updateUserPasswordAction } from '../../../../store/actions/authActions';
+
+
+
+class UpdateUserEmail extends Component {
+  state = {
+    password: ''
+  }
+
+  componentDidMount() {
+    if (!this.props.reauthenticateSuccess) {
+      this.props.history.push('/reauthenticate');
+    }
+  }
+
+  handleChange = (ev) => {
+    this.setState({
+      [ev.target.id]: ev.target.value
+    })
+  }
+
+  handleSubmit = (ev) => {
+    ev.preventDefault();
+
+    this.props.updateUserPassword(this.state);
+  }
+
+  render() {
+
+    console.log(this.props)
+    if (this.props.userUpdated) {
+      this.props.history.goBack();
+      return (<p> redirecting.. </p>);
+
+    }
+
+    if (!this.props.auth.uid) {
+      return <Redirect to='/login' />
+    }
+    return (
+      <div>
+        <h2>
+          update password
+        </h2>
+        <form onSubmit={this.handleSubmit}>
+          <div>
+            <label htmlFor="password">Password: </label>
+            <input type="password"
+              id="password"
+              onChange={this.handleChange}
+              value={this.state.password} />
+          </div>
+          <button>
+            update
+          </button>
+
+          {this.props.authError ? <p>{this.props.authError}</p> : null}
+          {this.props.userUpdated ? <p> updated email successfully </p> : null}
+        </form>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state) => {
+  console.log(state)
+  return {
+    auth: state.firebase.auth,
+    authError: state.auth.authError,
+    reauthenticateSuccess: state.auth.reauthenticateSuccess,
+    userUpdated: state.auth.userUpdated
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    updateUserPassword: (updateUser) => {
+      dispatch(updateUserPasswordAction(updateUser));
+    }
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(UpdateUserEmail)

--- a/src/container/Settings/UserSettings/UserSettingsForms/UpdateUserUsername.js
+++ b/src/container/Settings/UserSettings/UserSettingsForms/UpdateUserUsername.js
@@ -1,0 +1,79 @@
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+import { updateUserUsernameAction } from '../../../../store/actions/authActions';
+
+
+
+class UpdateUserEmail extends Component {
+  state = {
+    username: ''
+  }
+
+  handleChange = (ev) => {
+    this.setState({
+      [ev.target.id]: ev.target.value
+    })
+  }
+
+  handleSubmit = (ev) => {
+    ev.preventDefault();
+    let updateUser = {
+      ...this.state,
+      UID: this.props.auth.uid
+    }
+    this.props.updateUserUsername(updateUser);
+  }
+
+  render() {
+    if (this.props.userUpdated) {
+      this.props.history.goBack();
+      return (<p> redirecting.. </p>);
+    }
+
+    if (!this.props.auth.uid) {
+      return <Redirect to='/login' />
+    }
+    return (
+      <div>
+        <h2>
+          update username
+        </h2>
+        <form onSubmit={this.handleSubmit}>
+          <div>
+            <label htmlFor="username">Username: </label>
+            <input type="text"
+              id="username"
+              onChange={this.handleChange}
+              value={this.state.username} />
+          </div>
+          <button>
+            update
+          </button>
+
+          {this.props.authError ? <p>{this.props.authError}</p> : null}
+          {this.props.userUpdated ? <p> updated email successfully </p> : null}
+        </form>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    auth: state.firebase.auth,
+    authError: state.auth.authError,
+    userUpdated: state.auth.userUpdated
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    updateUserUsername: (updateUser) => {
+      dispatch(updateUserUsernameAction(updateUser));
+    }
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(UpdateUserEmail)

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,9 @@ const store = createStore(rootReducer,
   applyMiddleware(thunk.withExtraArgument({getFirebase,getFirestore})
   ),
   reduxFirestore(fbConfig),
+  // insufficient permission error when user signs out
+  // don't worry about it.
+  // https://github.com/prescottprue/react-redux-firebase/issues/494 
   reactReduxFirebase(fbConfig, { useFirestoreForProfile: true, userProfile: 'users', attachAuthIsReady: true })
 ));
 

--- a/src/store/actions/authActions.js
+++ b/src/store/actions/authActions.js
@@ -13,7 +13,101 @@ export const loginAction = (credentials) => {
       dispatch({ type: 'LOGIN_ERROR', err });
     })
   }
-}
+};
+
+export const reauthenticateUser = (reauthUser) => {
+  return (dispatch, getState, { getFirebase }) => {
+    const firebase = getFirebase();
+
+    let user = firebase.auth().currentUser;
+
+    // have to create the credential object
+    // https://github.com/angular/angularfire2/issues/491
+    const credential = firebase.auth.EmailAuthProvider.credential(reauthUser.email, reauthUser.password);
+
+    user.reauthenticateWithCredential(credential)
+      .then(() => {
+        dispatch({ type: 'REAUTHENTICATE_SUCCESS' });
+      })
+      .catch((err) => {
+        dispatch({ type: 'REAUTHENTICATE_ERROR', err });
+      });
+
+  }
+};
+
+/**
+ * when user updates their account information 
+ * certain variables need to be reseted
+ * so they can update their account information again 
+ * later
+ * 
+ * @return {function} - to delay dispatch
+ */
+
+export const resetStateForUpdateUserAction = () => {
+  return (dispatch) => {
+    dispatch({ type: 'RESET_STATE_UPDATED_USER' })
+  }
+};
+
+export const updateUserEmailAction = (updateUser) => {
+  return (dispatch, getState, { getFirebase, getFirestore }) => {
+    const firebase = getFirebase();
+
+    firebase.auth().currentUser.updateEmail(updateUser.email)
+      .then(() => {
+        console.log('update email');
+        dispatch({ type: 'UPDATE_USER_SUCCESS' });
+      })
+      .catch((err) => {
+        console.log(err, 'update email');
+        dispatch({ type: 'UPDATE_USER_ERROR', err });
+      });
+  }
+};
+
+export const updateUserPasswordAction = (updateUser) => {
+  return (dispatch, getState, { getFirebase }) => {
+    const firebase = getFirebase();
+
+    // only update password if it exist
+    if (updateUser.password) {
+      firebase.auth().currentUser.updatePassword(updateUser.password)
+        .then(() => {
+          console.log('update password');
+          dispatch({ type: 'UPDATE_USER_SUCCESS' });
+        })
+        .catch((err) => {
+          console.log(err, 'update password')
+          dispatch({ type: 'UPDATE_USER_ERROR', err })
+        });
+    }
+
+  }
+};
+
+export const updateUserUsernameAction = (updateUser) => {
+  return (dispatch, getState, { getFirestore }) => {
+    const firestore = getFirestore();
+
+    // only update username if it exist
+    let userCollection = firestore.collection('users').doc(updateUser.UID);
+    if (updateUser.username) {
+      userCollection.update({
+        username: updateUser.username
+      })
+      .then(() => {
+        console.log('update username');
+        dispatch({ type: 'UPDATE_USER_SUCCESS' });
+      })
+      .catch((err) => {
+        console.log('update username ', err)
+        dispatch({ type: 'UPDATE_USER_ERROR', err })
+      });
+    }
+  }
+};
 
 export const logOut = () => {
   return (dispatch, getState, { getFirebase }) => {
@@ -24,7 +118,7 @@ export const logOut = () => {
         dispatch({ type: 'LOGOUT_SUCCESS' });
       })
   }
-}
+};
 
 export const registerAction = (newUser) => {
   return (dispatch, getState, { getFirebase, getFirestore }) => {
@@ -52,4 +146,4 @@ export const registerAction = (newUser) => {
 
     console.log(newUser, 'Register Action');
   }
-}
+};

--- a/src/store/reducers/authReducer.js
+++ b/src/store/reducers/authReducer.js
@@ -1,5 +1,7 @@
 const initState = {
-  authError: null
+  authError: null,
+  userUpdate: false,
+  reauthenticateSuccess: false
 };
 
 const authReducer = (state=initState, action) => {
@@ -32,6 +34,56 @@ const authReducer = (state=initState, action) => {
       return {
         ...state,
         authError: action.err.message
+      }
+
+
+    case 'UPDATE_USER_ERROR':
+      console.log('update user error', action.err, action.err.code === 'auth/user-token-expired');
+
+      return {
+        ...state,
+        authError: action.err.message,
+        userUpdated: false
+      }
+    
+    case 'UPDATE_USER_SUCCESS':
+      console.log('update user success');
+      return {
+        ...state,
+        // this will be used to redirect the user
+        userUpdated: true,
+        reauthenticateSuccess: false
+      }
+
+    case 'REAUTHENTICATE_SUCCESS':
+      console.log('reauthenticate success');
+
+      return {
+        ...state,
+        reauthenticateSuccess: true,
+        authError: null
+      }
+
+    case 'REAUTHENTICATE_ERROR':
+      console.log('reauthenticate ERROR', action.err);
+
+      return {
+        ...state,
+        reauthenticateSuccess: false,
+        authError: action.err.message
+      }
+
+    
+    // reset the state of the user so 
+    // when they try to change some other senstive data
+    // it will make them reauthenticate
+    case 'RESET_STATE_UPDATED_USER':
+      console.log('RESETING state');
+      return {
+        ...state,
+        reauthenticateSuccess: false,
+        authError: null,
+        userUpdated: false
       }
 
     default:


### PR DESCRIPTION
add as per issue #25
Had to create separate pages/components for updating a user account information because firebase makes the user re-authenticate every time one of these are changed.

* create 3 components for updating user's username, password, and email
* create 3 different links for the 3 components
* create 3 actions to update a user account information
