### PR TITLE
add form validation to create and edit a build #29

### DIFF
--- a/src/container/Build/Build.js
+++ b/src/container/Build/Build.js
@@ -34,9 +34,24 @@ class Build extends Component {
   handleSubmit = (ev) => {
     ev.preventDefault();
 
-    this.props.createBuild(this.state);
+    if (this.state.title !== '' &&
+      this.state.champion !== '' &&
+      this.state.content !== '' &&
+      this.state.items.length &&
+      this.state.comp.length) {
 
-    this.props.history.push('/');
+      this.setState({
+        currentDataNeededFilled: ''
+      });
+
+        this.props.createBuild(this.state);
+        this.props.history.push('/');
+      } else {
+        this.setState({
+          currentDataNeededFilled: 'information is missing!'
+        });
+      }
+
   }
 
   render () {
@@ -44,22 +59,25 @@ class Build extends Component {
 
     if (!auth.uid) return <Redirect to='/login' />
 
+
     return (
       <form onSubmit={this.handleSubmit}>
         <h2>pick a title</h2>
-        <TitleFormBuild handleChange={this.handleChange} />
+        <TitleFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.title ? true : false } handleChange={this.handleChange} />
         <h2>pick your champion</h2>
-        <ChampionFormBuild handleChange={this.handleChange} />
+        <ChampionFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.champion ? true : false } handleChange={this.handleChange} />
         <h2>pick the best items for this champion</h2>
-        <ItemFormBuild handleChange={this.handleChange} />
+        <ItemFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.items.length ? true : false } handleChange={this.handleChange} />
         <h2>pick champions that work best with this champion</h2>
-        <CompFormBuild handleChange={this.handleChange} />
+        <CompFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.comp.length ? true : false } handleChange={this.handleChange} />
         <h2>write about why this is the best way to use this champion in team fight tactics</h2>
-        <ContentFormBuild handleChange={this.handleChange} />
+        <ContentFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.content ? true : false } handleChange={this.handleChange} />
         <div>
           <button>
             create
           </button>
+
+          {this.state.currentDataNeededFilled ? <p>{this.state.currentDataNeededFilled}</p> : null}
         </div>
       </form>
     );
@@ -73,7 +91,6 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = (dispatch) => {
-  console.log('dispatching action to create a build in BUILD.JS')
   return {
     createBuild: (build) => {
       return dispatch(createBuildAction(build))

--- a/src/container/Build/ChampionFormBuild.js
+++ b/src/container/Build/ChampionFormBuild.js
@@ -6,6 +6,7 @@ class ChampionFormBuild extends Component {
     filterChampions: [],
     imageURL: '',
     dataFilled: false,
+    currentDataNeededFilled: '',
     champions: [
       {"display":"fiora","lookUp":"Fiora"},{"display":"graves","lookUp":"Graves"},{"display":"kassadin","lookUp":"Kassadin"},{"display":"kha’zix","lookUp":"Khazix"},{"display":"mordekaiser","lookUp":"Mordekaiser"},{"display":"nidalee","lookUp":"Nidalee"},{"display":"tristana","lookUp":"Tristana"},{"display":"vayne","lookUp":"Vayne"},{"display":"warwick","lookUp":"Warwick"},{"display":"ahri","lookUp":"Ahri"},{"display":"blitzcrank","lookUp":"Blitzcrank"},{"display":"braum","lookUp":"Braum"},{"display":"darius ","lookUp":"Darius"},{"display":"elise","lookUp":"Elise"},{"display":"lissandra","lookUp":"Lissandra"},{"display":"lucian","lookUp":"Lucian"},{"display":"lulu","lookUp":"Lulu"},{"display":"pyke","lookUp":"Pyke"},{"display":"rek’sai","lookUp":"RekSai"},{"display":"shen","lookUp":"Shen"},{"display":"varus","lookUp":"Varus"},{"display":"zed","lookUp":"Zed"},{"display":"aatrox","lookUp":"Aatrox"},{"display":"ashe","lookUp":"Ashe"},{"display":"cho’gath","lookUp":"Chogath"},{"display":"evelynn","lookUp":"Evelynn"},{"display":"gangplank","lookUp":"Gangplank"},{"display":"katarina","lookUp":"Katarina"},{"display":"kennen","lookUp":"Kennen"},{"display":"morgana","lookUp":"Morgana"},{"display":"poppy","lookUp":"Poppy"},{"display":"rengar","lookUp":"Rengar"},{"display":"shyvana","lookUp":"Shyvana"},{"display":"veigar","lookUp":"Veigar"},{"display":"volibear","lookUp":"Volibear"},{"display":"akali ","lookUp":"Akali"},{"display":"aurelion sol","lookUp":"AurelionSol"},{"display":"brand","lookUp":"Brand"},{"display":"draven","lookUp":"Draven"},{"display":"gnar","lookUp":"Gnar"},{"display":"kindred","lookUp":"Kindred"},{"display":"leona","lookUp":"Leona"},{"display":"sejuani","lookUp":"Sejuani"},{"display":"anivia ","lookUp":"Anivia"},{"display":"karthus","lookUp":"Karthus"},{"display":"kayle","lookUp":"Kayle"},{"display":"miss fortune","lookUp":"MissFortune"},{"display":"swain","lookUp":"Swain"},{"display":"yasuo","lookUp":"Yasuo"}]
   }
@@ -47,12 +48,14 @@ class ChampionFormBuild extends Component {
       return champion.display.includes(ev.target.value.toLowerCase());
     });
 
-    console.log(ev.target.value);
-
     this.setState({
       filterChampions: filterdChamps,
       champion: ev.target.value,
-      imageURL: ''
+      imageURL: '',
+
+      // if the input is changing that means a champion isn't picked
+      // display this to the user
+      currentDataNeededFilled: 'a champion is needed!'
     });
 
     // passing the state of the champion to the parent
@@ -69,9 +72,9 @@ class ChampionFormBuild extends Component {
     this.setState({
       champion: ev.target.id,
       filterChampions: [],
-      imageURL: championIcon
+      imageURL: championIcon,
+      currentDataNeededFilled: ''
     });
-
     // pass the state of the champion to the parent
     this.props.handleChange({
       champion: ev.target.id,
@@ -110,6 +113,22 @@ class ChampionFormBuild extends Component {
             onChange={this.handleChange}
             value={this.state.champion} />
         </div>
+
+        {/* form validation for the user */}
+        
+        {
+          this.state.currentDataNeededFilled ? 
+          <p>{this.state.currentDataNeededFilled }</p> : 
+          null 
+        }
+
+        {/* display errors if a user doesn't type anything or miss wiht the inputs */}
+
+        {
+          !this.state.currentDataNeededFilled && this.props.missingInfo ?
+            <p>a champion is needed!</p> :
+            null
+        }
         {filterChampions}
       </React.Fragment>
     )

--- a/src/container/Build/CompFormBuild.js
+++ b/src/container/Build/CompFormBuild.js
@@ -6,6 +6,7 @@ class CompFormBuild extends Component {
     champion: '',
     filteredChampions: [],
     dataFilled: false,
+    currentDataNeededFilled: '',
     champions: [{ "display": "fiora", "lookUp": "Fiora" }, { "display": "graves", "lookUp": "Graves" }, { "display": "kassadin", "lookUp": "Kassadin" }, { "display": "kha’zix", "lookUp": "Khazix" }, { "display": "mordekaiser", "lookUp": "Mordekaiser" }, { "display": "nidalee", "lookUp": "Nidalee" }, { "display": "tristana", "lookUp": "Tristana" }, { "display": "vayne", "lookUp": "Vayne" }, { "display": "warwick", "lookUp": "Warwick" }, { "display": "ahri", "lookUp": "Ahri" }, { "display": "blitzcrank", "lookUp": "Blitzcrank" }, { "display": "braum", "lookUp": "Braum" }, { "display": "darius ", "lookUp": "Darius" }, { "display": "elise", "lookUp": "Elise" }, { "display": "lissandra", "lookUp": "Lissandra" }, { "display": "lucian", "lookUp": "Lucian" }, { "display": "lulu", "lookUp": "Lulu" }, { "display": "pyke", "lookUp": "Pyke" }, { "display": "rek’sai", "lookUp": "RekSai" }, { "display": "shen", "lookUp": "Shen" }, { "display": "varus", "lookUp": "Varus" }, { "display": "zed", "lookUp": "Zed" }, { "display": "aatrox", "lookUp": "Aatrox" }, { "display": "ashe", "lookUp": "Ashe" }, { "display": "cho’gath", "lookUp": "Chogath" }, { "display": "evelynn", "lookUp": "Evelynn" }, { "display": "gangplank", "lookUp": "Gangplank" }, { "display": "katarina", "lookUp": "Katarina" }, { "display": "kennen", "lookUp": "Kennen" }, { "display": "morgana", "lookUp": "Morgana" }, { "display": "poppy", "lookUp": "Poppy" }, { "display": "rengar", "lookUp": "Rengar" }, { "display": "shyvana", "lookUp": "Shyvana" }, { "display": "veigar", "lookUp": "Veigar" }, { "display": "volibear", "lookUp": "Volibear" }, { "display": "akali ", "lookUp": "Akali" }, { "display": "aurelion sol", "lookUp": "AurelionSol" }, { "display": "brand", "lookUp": "Brand" }, { "display": "draven", "lookUp": "Draven" }, { "display": "gnar", "lookUp": "Gnar" }, { "display": "kindred", "lookUp": "Kindred" }, { "display": "leona", "lookUp": "Leona" }, { "display": "sejuani", "lookUp": "Sejuani" }, { "display": "anivia ", "lookUp": "Anivia" }, { "display": "karthus", "lookUp": "Karthus" }, { "display": "kayle", "lookUp": "Kayle" }, { "display": "miss fortune", "lookUp": "MissFortune" }, { "display": "swain", "lookUp": "Swain" }, { "display": "yasuo", "lookUp": "Yasuo" }]
   }
 
@@ -54,8 +55,15 @@ class CompFormBuild extends Component {
 
   handleItemClick = (ev) => {
     let arr = [...this.state.pickedChampions, ev.target.id];
+    let formValidationString = '';
+
+    if (arr.length) {
+      formValidationString = '';
+    }
+    
     this.setState({
-      pickedChampions: arr
+      pickedChampions: arr,
+      currentDataNeededFilled: formValidationString
     }, () => {
       this.props.handleChange({
         comp: this.state.pickedChampions
@@ -65,13 +73,19 @@ class CompFormBuild extends Component {
 
   handleRemoveItem = (ev) => {
     let arr = this.state.pickedChampions.filter((champ, index) => {
-      console.log(index, ev.target.id)
       return index !== Number(ev.target.id);
     });
 
+    let formValidationString = '';
+
+
+    if (arr.length === 0) {
+      formValidationString = 'a single champion is needed!';
+    }
 
     this.setState({
-      pickedChampions: arr
+      pickedChampions: arr,
+      currentDataNeededFilled: formValidationString
     }, () => {
       this.props.handleChange({
         comp: this.state.pickedChampions
@@ -126,6 +140,21 @@ class CompFormBuild extends Component {
             onChange={this.handleChange}
             value={this.state.champion}>
           </input>
+
+          {/* form validation for the user */}
+
+          {
+            this.state.currentDataNeededFilled ?
+              <p>{this.state.currentDataNeededFilled}</p> :
+              null
+          }
+
+          {/* display errors if a user doesn't type anything or miss wiht the inputs */}
+          {
+            !this.state.currentDataNeededFilled && this.props.missingInfo ?
+              <p>a single champion is needed!</p> :
+              null
+          }
         </div>
         <div>
           {displayedChampions}

--- a/src/container/Build/ContentFormBuild.js
+++ b/src/container/Build/ContentFormBuild.js
@@ -22,6 +22,16 @@ class ContentFormBuild extends Component {
   handleChange = (ev) => {
     this.setState({
       [ev.target.id]: ev.target.value
+    }, () => {
+        if (this.state.content === '') {
+          this.setState({
+            currentDataNeededFilled: 'you need to write something!'
+          });
+        } else {
+          this.setState({
+            currentDataNeededFilled: ''
+          });
+        }
     });
 
     // lift the state of this component to the main component to be able to save to a database
@@ -30,7 +40,7 @@ class ContentFormBuild extends Component {
 
   render () {
     return (
-      <React.Fragment>
+      <div>
         <label htmlFor='content'></label>
         <textarea 
           id='content'
@@ -38,7 +48,22 @@ class ContentFormBuild extends Component {
           cols='100'
           rows='5'
           onChange={this.handleChange} />
-      </React.Fragment>
+
+        {/* form validation for the user */}
+
+        {
+          this.state.currentDataNeededFilled ?
+            <p>{this.state.currentDataNeededFilled}</p> :
+            null
+        }
+
+        {/* display errors if a user doesn't type anything or miss wiht the inputs */}
+        {
+          !this.state.currentDataNeededFilled && this.props.missingInfo ?
+            <p>you need to write something!</p> :
+            null
+        }
+      </div>
     )
   }
 }

--- a/src/container/Build/ItemsFormBuild.js
+++ b/src/container/Build/ItemsFormBuild.js
@@ -5,6 +5,7 @@ class ItemsFormBuild extends Component {
     pickedItems: [],
     item: '',
     filteredItems: [],
+    currentDataNeededFilled: '',
     dataFilled: false,
     items: [
       {"display":"force of nature","lookUp":"forceofnature"},{"display":"frozen heart","lookUp":"frozenheart"},{"display":"guinsoo's rageblade","lookUp":"guinsoosrageblade"},{"display":"phantom dancer","lookUp":"phantomdancer"},{"display":"rapid firecannon","lookUp":"rapidfirecannon"},{"display":"spear of shojin","lookUp":"spearofshojin"},{"display":"blade of the ruined king","lookUp":"bladeoftheruinedking"},{"display":"bloodthirster","lookUp":"bloodthirster"},{"display":"frozen mallet","lookUp":"frozenmallet"},{"display":"luden's echo","lookUp":"ludensecho"},{"display":"morellonomicon","lookUp":"morellonomicon"},{"display":"seraph's embrace","lookUp":"seraphsembrace"},{"display":"thornmail","lookUp":"thornmail"},{"display":"youmuu's ghostblade","lookUp":"youmuusghostblade"},{"display":"yuumi","lookUp":"yuumi"},{"display":"zeke's herald","lookUp":"zekesherald"},{"display":"zephyr","lookUp":"zephyr"},{"display":"cursed blade","lookUp":"cursedblade"},{"display":"dragon's claw","lookUp":"dragonsclaw"},{"display":"hextech gunblade","lookUp":"hextechgunblade"},{"display":"infinity edge","lookUp":"infinityedge"},{"display":"locket of the iron solari","lookUp":"locketoftheironsolari"},{"display":"rabadon's deathcap","lookUp":"rabadonsdeathcap"},{"display":"red buff","lookUp":"redbuff"},{"display":"runaan's hurricane","lookUp":"runaanshurricane"},{"display":"statikk shiv","lookUp":"statikkshiv"},{"display":"sword of the divine","lookUp":"swordofthedivine"},{"display":"titanic hydra","lookUp":"titanichydra"},{"display":"warmog's armor","lookUp":"warmogsarmor"},{"display":"hush","lookUp":"hush"},{"display":"ionic spark","lookUp":"ionicspark"},{"display":"knight's vow","lookUp":"knightsvow"},{"display":"sword breaker","lookUp":"swordbreaker"},{"display":"darkin","lookUp":"darkin"},{"display":"guardian angel","lookUp":"guardianangel"},{"display":"redemption","lookUp":"redemption"}]
@@ -49,26 +50,49 @@ class ItemsFormBuild extends Component {
   }
 
   handleItemClick = (ev) => {
-    let arr = [...this.state.pickedItems, ev.target.id];
-    this.setState({
-      pickedItems: arr
-    }, () => {
+    const maxAmountOfBuilds = 3;
+
+    if (this.state.pickedItems.length < maxAmountOfBuilds) {
+      let arr = [...this.state.pickedItems, ev.target.id];
+      let formValidationString = '';
+
+      if (arr.length < maxAmountOfBuilds) {
+        formValidationString = (maxAmountOfBuilds - arr.length) + ' items are needed';
+      } else if (arr.length === maxAmountOfBuilds) {
+        formValidationString = ''
+      }
+
+      this.setState({
+        pickedItems: arr,
+        // dynamically tell the user how many items is needed
+        currentDataNeededFilled: formValidationString
+      }, () => {
         this.props.handleChange({
           items: this.state.pickedItems
         });
-    });
+      });
+    }
   }
 
   handleRemoveItem = (ev) => {
     let arr = this.state.pickedItems.filter((item, index) => {
-      console.log(index, ev.target.id)
       return index !== Number(ev.target.id);
     });
+    let maxAmountOfBuilds = 3;
 
-    console.log(arr);
+    let formValidationString = '';
+
+    if (arr.length < maxAmountOfBuilds) {
+      formValidationString = (maxAmountOfBuilds - arr.length) + ' items are needed'
+    } else if (arr.length === maxAmountOfBuilds) {
+      formValidationString = ''
+    }
   
     this.setState({
-      pickedItems: arr
+      pickedItems: arr,
+
+      // dynamically tell the user how many items is needed
+      currentDataNeededFilled: formValidationString
     }, () => {
       this.props.handleChange({
         items: this.state.pickedItems
@@ -122,6 +146,20 @@ class ItemsFormBuild extends Component {
             onChange={this.handleChange}
             value={this.state.item}>
           </input>
+          {/* form validation for the user */}
+
+          {
+            this.state.currentDataNeededFilled ?
+              <p>{this.state.currentDataNeededFilled}</p> :
+              null
+          }
+
+          {/* display errors if a user doesn't type anything or miss wiht the inputs */}
+          {
+            !this.state.currentDataNeededFilled && this.props.missingInfo ?
+              <p>at most 3 items are needed</p> :
+              null
+          }
         </div>
         <div>
           { items }

--- a/src/container/Build/TitleFormBuild.js
+++ b/src/container/Build/TitleFormBuild.js
@@ -3,7 +3,8 @@ import React, {Component} from 'react';
 class TitleFormBuild extends Component {
   state = {
     title: '',
-    dataFilled: false
+    dataFilled: false,
+    currentDataNeededFilled: ''
   }
 
   // pass down the props of the parent component
@@ -22,6 +23,16 @@ class TitleFormBuild extends Component {
   handleChange = (ev) => {
     this.setState({
       [ev.target.id]: ev.target.value
+    }, () => {
+      if (this.state.title === '') {
+        this.setState({
+          currentDataNeededFilled: 'A title is needed'
+        });
+      } else {
+        this.setState({
+          currentDataNeededFilled: ''
+        });
+      }
     });
 
     // passing the state of the champion to the parent
@@ -33,6 +44,9 @@ class TitleFormBuild extends Component {
   }
 
   render() {
+
+    console.log(this.props)
+
     return (
       <div>
         <label
@@ -42,6 +56,18 @@ class TitleFormBuild extends Component {
           id='title'
           onChange={this.handleChange}
           value={this.state.title} />
+        { 
+          this.state.currentDataNeededFilled ? 
+          <p>{ this.state.currentDataNeededFilled }</p> : 
+          null 
+        }
+
+        {/* display errors if a user doesn't type anything or miss wiht the inputs */}
+        {
+          !this.state.currentDataNeededFilled && this.props.missingInfo ?
+            <p>A title is needed</p> :
+            null
+        }
       </div>
     );
   }

--- a/src/container/Settings/BuildSettings/EditBuild/EditBuild.js
+++ b/src/container/Settings/BuildSettings/EditBuild/EditBuild.js
@@ -55,15 +55,31 @@ class EditBuild extends Component {
   handleSubmit = (ev) => {
     ev.preventDefault();
 
-    // pass the id of the build so
-    // firestore can fetch 
-    // the correct build
-    let updatedBuild = {
-      ...this.state,
-      id: this.props.match.params.id
-    }
+    if (this.state.title !== '' &&
+        this.state.champion !== '' &&
+        this.state.content !== '' &&
+        this.state.items.length &&
+        this.state.comp.length) {
 
-    this.props.editBuild(updatedBuild, this.props.history);
+      this.setState({
+        currentDataNeededFilled: ''
+      });
+
+      // pass the id of the build so
+      // firestore can fetch 
+      // the correct build
+      let updatedBuild = {
+        ...this.state,
+        id: this.props.match.params.id
+      }
+
+      this.props.editBuild(updatedBuild, this.props.history);
+
+    } else {
+      this.setState({
+        currentDataNeededFilled: 'information is missing!'
+      });
+    }
 
   }
 
@@ -76,24 +92,26 @@ class EditBuild extends Component {
     return (
       <form onSubmit={this.handleSubmit}>
         <h2>pick a title</h2>
-        <TitleFormBuild title={ build ? build.title : '' } handleChange={this.handleChange} />
+        <TitleFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.title ? true : false} title={ build ? build.title : '' } handleChange={this.handleChange} />
         
         <h2>pick your champion</h2>
-        <ChampionFormBuild champion={build ? build.champion : ''} handleChange={this.handleChange} />
+        <ChampionFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.champion ? true : false} champion={build ? build.champion : ''} handleChange={this.handleChange} />
         
         <h2>pick the best items for this champion</h2>
-        <ItemFormBuild items={ build ? build.items : []  } handleChange={this.handleChange} />
+        <ItemFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.items.length ? true : false} items={ build ? build.items : []  } handleChange={this.handleChange} />
         
         <h2>pick champions that work best with this champion</h2>
-        <CompFormBuild comp={build ? build.comp : []} handleChange={this.handleChange} />
+        <CompFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.comp.length ? true : false} comp={build ? build.comp : []} handleChange={this.handleChange} />
         
         <h2>write about why this is the best way to use this champion in team fight tactics</h2>
-        <ContentFormBuild content={build ? build.content : ''} handleChange={this.handleChange} />
+        <ContentFormBuild missingInfo={this.state.currentDataNeededFilled && !this.state.content ? true : false} content={build ? build.content : ''} handleChange={this.handleChange} />
         <div>
           <button>
             update
           </button>
           { authError ? <p>{ authError }</p>: null }
+
+          { this.state.currentDataNeededFilled ? <p>{ this.state.currentDataNeededFilled }</p> : null }
         </div>
       </form>
     );


### PR DESCRIPTION
add as per issue #29

* add a currentDataNeededFilled state to each input component and add form validation live as the user typed in the input or and when an item or champion is added

* when the user submits the form to create a build initially it wouldn't show the form validation errors so i passed down the state of the form validation down to the inputs as a prop and displayed it to the user only if the state of the input that was submit was empty and if it already didn't have any sort of validation 